### PR TITLE
implement data persistence between sessions

### DIFF
--- a/Assets/Scripts/DataManager.cs
+++ b/Assets/Scripts/DataManager.cs
@@ -1,12 +1,14 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using System.IO;
 
 public class DataManager : MonoBehaviour
 {
     public static DataManager Instance;
+    public string currentPlayerName;
     public string playerName;
-    public int bestScore = 0;
+    public int bestScore;
 
     private void Awake()
     {
@@ -17,5 +19,41 @@ public class DataManager : MonoBehaviour
 
         Instance = this;
         DontDestroyOnLoad(gameObject);
+        LoadBestScore();
+    }
+
+    [System.Serializable]
+    class SaveData
+    {
+        public string playerName;
+        public int bestScore;
+    }
+
+    public void SaveBestScore()
+    {
+        SaveData data = new SaveData();
+        data.playerName = playerName;
+        data.bestScore = bestScore;
+
+        string json = JsonUtility.ToJson(data);
+        File.WriteAllText(Application.persistentDataPath + "/savefile.json", json);
+    }
+
+    public void LoadBestScore()
+    {
+        string path = Application.persistentDataPath + "/savefile.json";
+
+        if (File.Exists(path))
+        {
+            string json= File.ReadAllText(path);
+            SaveData data = JsonUtility.FromJson<SaveData>(json);
+
+            playerName = data.playerName;
+            bestScore = data.bestScore;
+        } else
+        {
+            playerName = currentPlayerName;
+            //bestScore = 0; //not needed, apparently automatically 0 if no value specified
+        }
     }
 }

--- a/Assets/Scripts/MainManager.cs
+++ b/Assets/Scripts/MainManager.cs
@@ -18,7 +18,6 @@ public class MainManager : MonoBehaviour
     private int m_Points;
     
     private bool m_GameOver = false;
-
     
     // Start is called before the first frame update
     void Start()
@@ -81,9 +80,13 @@ public class MainManager : MonoBehaviour
         m_GameOver = true;
         GameOverText.SetActive(true);
 
-        if (m_GameOver && m_Points > DataManager.Instance.bestScore)
+        DataManager.Instance.SaveBestScore();
+
+        if (m_Points > DataManager.Instance.bestScore)
         {
+            DataManager.Instance.playerName = DataManager.Instance.currentPlayerName;
             DataManager.Instance.bestScore = m_Points;
+            UpdateBestScoreText();
         }
     }
 }

--- a/Assets/Scripts/MenuUIHandler.cs
+++ b/Assets/Scripts/MenuUIHandler.cs
@@ -8,7 +8,7 @@ using TMPro;
 //per the tutorial, it can sometimes be helpful to load UI scripts after other scripts have loaded.
 public class MenuUIHandler : MonoBehaviour
 {
-    public TMP_InputField nameInput;
+    private TMP_InputField nameInput;
     private void Start()
     {
         nameInput = GameObject.Find("Name Input").GetComponent<TMP_InputField>();
@@ -16,7 +16,7 @@ public class MenuUIHandler : MonoBehaviour
 
     private void Update()
     {
-        DataManager.Instance.playerName = nameInput.text;
+        DataManager.Instance.currentPlayerName = nameInput.text;
     }
 
     public void StartNewGame()


### PR DESCRIPTION
* Add serializable SaveData class, SaveBestScore() and LoadBestScore() methods to write current session data to JSON & load data from previous sessions within DataManager.cs.
* Create an extra variable to hold current player name and store menu input text in there
* Call SaveBestScore() in GameOver() method in MainManager.cs and LoadBestScore() on Awake() method in DataManager.cs.
* Note: I chose to save new top score in GameOver method but if you want it to update as soon as current best score is beaten, can move best score/player updating logic from GameOver() method into Update() function of MainManager.cs